### PR TITLE
Allow an environment variable to configure the GitHub API base url.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21,7 +21,8 @@ const core_1 = __nccwpck_require__(762);
 class GithubHelper {
     constructor(token) {
         this.octokit = new core_1.Octokit({
-            auth: token
+            auth: token,
+            baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com'
         });
     }
     getPullRequestId(owner, repo, pullRequestNumber) {

--- a/src/github-helper.ts
+++ b/src/github-helper.ts
@@ -8,7 +8,8 @@ export class GithubHelper {
 
   constructor(token: string) {
     this.octokit = new Octokit({
-      auth: token
+      auth: token,
+      baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com'
     })
   }
 


### PR DESCRIPTION
Adds support for GitHub Enterprise.

Matches [create-pull-request](https://github.com/peter-evans/create-pull-request/blob/main/src/github-helper.ts#L27) and resolves https://github.com/peter-evans/enable-pull-request-automerge/issues/147

